### PR TITLE
feat: wallet payments

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stripe_presenter_plugin (0.0.1)
+    stripe_presenter_plugin (1.3.0)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/coprl/presenters/plugins/stripe.rb
+++ b/lib/coprl/presenters/plugins/stripe.rb
@@ -1,5 +1,6 @@
 require_relative 'stripe/components/stripe_js'
 require_relative 'stripe/components/credit_card_form'
+require_relative 'stripe/components/payment_request_form'
 require_relative 'stripe/components/actions/create_stripe_bank_account_token'
 require_relative 'stripe/components/actions/tokenize_credit_card'
 
@@ -53,6 +54,15 @@ module Coprl
           def stripe_credit_card_form(stripe_publishable_key:, **attributes, &block)
             self << Stripe::Components::CreditCardForm.new(stripe_publishable_key,parent: self, **attributes, &block)
           end
+
+          def stripe_payment_request_form(stripe_publishable_key:, description:, total:, **attributes, &block)
+            self << Stripe::Components::PaymentRequestForm.new(stripe_publishable_key,
+                                                               description: description,
+                                                               total: total,
+                                                               parent: self,
+                                                               **attributes,
+                                                               &block)
+          end
         end
 
         module DSLEventActions
@@ -93,6 +103,11 @@ module Coprl
                                  index: index}
           end
 
+          def render_stripe_payment_request_form(comp, render:, components:, index:)
+            render.call :erb, :payment_request_form,
+                        views: view_dir_stripe(comp),
+                        locals: {comp: comp, components: components, index: index}
+          end
         end
 
         module WebClientActions

--- a/lib/coprl/presenters/plugins/stripe/components/credit_card_form.rb
+++ b/lib/coprl/presenters/plugins/stripe/components/credit_card_form.rb
@@ -7,14 +7,19 @@ module Coprl
         module Components
           class CreditCardForm < DSL::Components::EventBase
 
-            attr_reader :stripe_publishable_key, :address_config, :currency, :form_type
+            attr_reader :stripe_publishable_key,
+                        :address_config,
+                        :currency,
+                        :form_type
 
             def initialize(stripe_publishable_key, **attribs, &block)
               @stripe_publishable_key = stripe_publishable_key
               @address_config = attribs.delete(:address_config){ {} }
               @currency = attribs.delete(:currency){ 'usd' }
               @form_type = attribs[:form_type] || :multi_line
+
               super(type: :stripe_credit_card_form, **attribs, &block)
+
               expand!
             end
 

--- a/lib/coprl/presenters/plugins/stripe/components/payment_request_form.rb
+++ b/lib/coprl/presenters/plugins/stripe/components/payment_request_form.rb
@@ -1,0 +1,80 @@
+require 'coprl/presenters/dsl/components/event_base'
+
+module Coprl
+  module Presenters
+    module Plugins
+      module Stripe
+        module Components
+          class PaymentRequestForm < DSL::Components::EventBase
+            attr_reader :stripe_publishable_key,
+                        :description,
+                        :total,
+                        :payment_intent_path,
+                        :options,
+                        :shipping_options
+
+            def initialize(stripe_publishable_key,
+                           description:,
+                           total:,
+                           payment_intent_path:,
+                           shipping_options: [],
+                           **attributes,
+                           &block)
+              @stripe_publishable_key = stripe_publishable_key
+              @description = description
+              @total = total
+              @payment_intent_path = payment_intent_path
+              @options = DEFAULT_OPTIONS.merge(attributes.slice(*DEFAULT_OPTIONS.keys))
+              @shipping_options = validate_shipping_options(shipping_options)
+
+              super(type: :stripe_payment_request_form, **attributes, &block)
+
+              expand!
+            end
+
+            private
+
+            DEFAULT_OPTIONS = {
+              country: 'US',
+              currency: 'usd',
+              request_name: true,
+              request_email: true,
+              request_shipping: false
+            }.freeze
+
+            def validate_shipping_options(shipping_options)
+              if @options[:request_shipping] && shipping_options.empty?
+                raise Errors::ParameterValidation, 'request_shipping requires at least one shipping option'
+              end
+
+              shipping_options.map { |it| validate_shipping_option(it) }
+            end
+
+            def validate_shipping_option(shipping_option)
+              id = require_key_or_method(shipping_option, :id).to_s
+              label = require_key_or_method(shipping_option, :label).to_s
+              detail = require_key_or_method(shipping_option, :detail).to_s
+              amount = require_key_or_method(shipping_option, :amount).to_i
+
+              if amount < 0
+                raise ArgumentError, 'shipping option amount must be a nonnegative integer'
+              end
+
+              {id: id, label: label, detail: detail, amount: amount}
+            end
+
+            def require_key_or_method(thing, name)
+              if thing.respond_to?(:key?) && thing.key?(name)
+                return thing[name]
+              elsif thing.respond_to?(name)
+                return thing.public_send(name)
+              end
+
+              raise ArgumentError, "missing required key or method #{name}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/stripe_presenter_plugin.rb
+++ b/lib/stripe_presenter_plugin.rb
@@ -1,1 +1,1 @@
-require_relative 'coprl/presenters/plugins/stripe/stripe'
+require_relative 'coprl/presenters/plugins/stripe'

--- a/lib/stripe_presenter_plugin/version.rb
+++ b/lib/stripe_presenter_plugin/version.rb
@@ -1,3 +1,3 @@
 module StripePresenterPlugin
-  VERSION = "0.0.1"
+  VERSION = "1.3.0"
 end

--- a/views/assets/css/credit_card_form.css
+++ b/views/assets/css/credit_card_form.css
@@ -4,6 +4,11 @@
     padding: 18px;
 }
 
+.sr-payment-form .mdc-text-field {
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
 /* Single line component styles */
 .v-stripe_credit_card_form_single_line #card-errors {
     color: #DC1F3C;
@@ -25,6 +30,7 @@
 * {
     box-sizing: border-box;
 }
+
 body {
     font-family: var(--body-font-family);
     font-size: 16px;
@@ -44,6 +50,7 @@ body {
     min-height: 100vh;
     margin: 0 auto;
 }
+
 .sr-main {
     display: flex;
     flex-direction: column;
@@ -68,8 +75,8 @@ body {
 }
 
 /* Inputs */
-.sr-input,
-input[type="text"] {
+.sr-payment-form .sr-input,
+.sr-payment-form input[type="text"] {
     border: 1px solid var(--gray-border);
     border-radius: var(--radius);
     padding: 5px 12px;
@@ -81,19 +88,22 @@ input[type="text"] {
     -webkit-appearance: none;
     appearance: none;
 }
-.sr-input:focus,
-input[type="text"]:focus,
-button:focus,
-.focused {
+
+.sr-payment-form .sr-input:focus,
+.sr-payment-form input[type="text"]:focus,
+.sr-payment-form button:focus,
+.sr-payment-form .focused {
     /*box-shadow: 0 0 0 1px rgba(50, 151, 211, 0.3), 0 1px 1px 0 rgba(0, 0, 0, 0.07),
     0 0 0 4px rgba(50, 151, 211, 0.3); */
     outline: none;
     z-index: 9;
 }
-.sr-input::placeholder,
-input[type="text"]::placeholder {
+
+.sr-payment-form .sr-input::placeholder,
+.sr-payment-form input[type="text"]::placeholder {
     color: var(--gray-light);
 }
+
 .sr-result {
     height: 44px;
     -webkit-transition: height 1s ease;
@@ -103,9 +113,11 @@ input[type="text"]::placeholder {
     color: var(--font-color);
     overflow: auto;
 }
+
 .sr-result code {
     overflow: scroll;
 }
+
 .sr-result.expand {
     height: 350px;
 }
@@ -116,23 +128,23 @@ input[type="text"]::placeholder {
     border-radius: 7px;
 }
 
-a {
+.sr-payment-form a {
     color: var(--link-color);
     text-decoration: none;
     transition: all 0.2s ease;
 }
 
-a:hover {
+.sr-payment-form a:hover {
     filter: brightness(0.8);
 }
 
-a:active {
+.sr-payment-form a:active {
     filter: brightness(0.5);
 }
 
 /* Code block */
-code,
-pre {
+.sr-payment-form code,
+.sr-payment-form pre {
     font-family: "SF Mono", "IBM Plex Mono", "Menlo", monospace;
     font-size: 12px;
 }

--- a/views/assets/css/credit_card_form.css
+++ b/views/assets/css/credit_card_form.css
@@ -1,14 +1,10 @@
-/* Single line component styles */
+/* Multi-line component styles */
 .v-stripe_credit_card_form_multi_line .v-stripe-element {
     width: 100%;
     padding: 18px;
 }
 
-/* Multi-line component styles */
-.v-stripe_credit_card_form_single_line {
-    max-width: 500px;
-}
-
+/* Single line component styles */
 .v-stripe_credit_card_form_single_line #card-errors {
     color: #DC1F3C;
 }

--- a/views/assets/js/credit_card_form.js
+++ b/views/assets/js/credit_card_form.js
@@ -1,10 +1,10 @@
 class StripeCreditCardForm {
   constructor(element) {
-    console.log('\tStripeCreditCardForm');
+    console.debug('\tStripeCreditCardForm');
     this.element = element;
     this.data = this.element.dataset;
     this.stripe = Stripe(this.data.stripePublishableKey);
-    this.formType = this.data.formType
+    this.formType = this.data.formType;
 
     const elements = this.stripe.elements();
 
@@ -47,7 +47,6 @@ class StripeCreditCardForm {
       this.cardCvc = elements.create('cardCvc', {style: style});
       this.cardCvc.mount('#card-cvc');
     }
-
   }
 
   stripeTokenData() {

--- a/views/assets/js/credit_card_form.js
+++ b/views/assets/js/credit_card_form.js
@@ -1,106 +1,173 @@
-class StripeCreditCardForm {
-  constructor(element) {
-    console.debug('\tStripeCreditCardForm');
-    this.element = element;
-    this.data = this.element.dataset;
-    this.stripe = Stripe(this.data.stripePublishableKey);
-    this.formType = this.data.formType;
-
-    const elements = this.stripe.elements();
-
-    const style = {
-      base: {
-        color: '#32325d',
-        fontFamily: '"Helvetica Neue", Helvetica, sans-serif',
-        fontSmoothing: 'antialiased',
-        fontSize: '16px',
-        '::placeholder': {
-          color: '#aab7c4'
-        }
-      },
-      invalid: {
-        color: '#fa755a',
-        iconColor: '#fa755a'
+(function() {
+  // stripe.com/docs/js/elements_object/create_element#elements_create-options-classes
+  const BASE_CLASS_NAME = 'v-stripe-element';
+  const COMPLETE_CLASS_NAME = `${BASE_CLASS_NAME}--complete`;
+  const EMPTY_CLASS_NAME = `${BASE_CLASS_NAME}--empty`;
+  const FOCUSED_CLASS_NAME = `${BASE_CLASS_NAME}--focused`;
+  const INVALID_CLASS_NAME = `${BASE_CLASS_NAME}--invalid`;
+  const AUTOFILLED_CLASS_NAME = `${BASE_CLASS_NAME}--autofilled`;
+  const ELEMENT_STYLE = {
+    base: {
+      color: '#32325d',
+      fontFamily: '"Helvetica Neue", Helvetica, sans-serif',
+      fontSmoothing: 'antialiased',
+      fontSize: '16px',
+      '::placeholder': {
+        color: '#aab7c4'
       }
-    };
+    },
+    invalid: {
+      color: '#fa755a',
+      iconColor: '#fa755a'
+    }
+  };
 
-    if (this.formType === 'single_line') {
-      this.cardNumber = elements.create('card', {style: style});
-      this.cardNumber.mount('#card-element');
-      // Handle real-time validation errors from the card Element.
-      this.cardNumber.on('change', function(event) {
-        const displayError = document.getElementById('card-errors');
-        if (event.error) {
-          displayError.textContent = event.error.message;
-        } else {
-          displayError.textContent = '';
+  // stripe.com/docs/js/elements_object/create_element#elements_create-options
+  const ELEMENT_OPTIONS = {
+    style: ELEMENT_STYLE,
+    classes: {
+      base: BASE_CLASS_NAME,
+      complete: COMPLETE_CLASS_NAME,
+      empty: EMPTY_CLASS_NAME,
+      focus: FOCUSED_CLASS_NAME,
+      invalid: INVALID_CLASS_NAME,
+      webkitAutofill: AUTOFILLED_CLASS_NAME
+    }
+  }
+
+  class StripeCreditCardForm {
+    constructor(element) {
+      console.debug('\tStripeCreditCardForm');
+      this.element = element;
+      this.data = this.element.dataset;
+      this.stripe = Stripe(this.data.stripePublishableKey);
+      this.formType = this.data.formType;
+      this.elements = this.stripe.elements();
+
+      if (this.formType === 'single_line') {
+        const cardElement = document.querySelector('#card-element');
+        this.cardNumber = this.elements.create('card', Object.assign({}, ELEMENT_OPTIONS, {hidePostalCode: true}));
+        this.cardNumber.mount(cardElement);
+        this.cardNumber.on('change', event => handleElementChange(event, cardElement));
+      }
+      else {
+        const cardNumberElement = document.querySelector('#card-number');
+        this.cardNumber = this.elements.create('cardNumber', Object.assign({}, ELEMENT_OPTIONS, {showIcon: true}));
+        this.cardNumber.mount(cardNumberElement);
+        this.cardNumber.on('change', event => handleElementChange(event, cardNumberElement));
+
+        const cardExpiryElement = document.querySelector('#card-expiry');
+        this.cardExpiry = this.elements.create('cardExpiry', ELEMENT_OPTIONS);
+        this.cardExpiry.mount(cardExpiryElement);
+        this.cardExpiry.on('change', event => handleElementChange(event, cardExpiryElement));
+
+        const cardCvcElement = document.querySelector('#card-cvc');
+        this.cardCvc = this.elements.create('cardCvc', ELEMENT_OPTIONS);
+        this.cardCvc.mount(cardCvcElement);
+        this.cardCvc.on('change', event => handleElementChange(event, cardCvcElement));
+      }
+    }
+
+    stripeTokenData() {
+      let data = {currency: this.data.currency}
+      if (this.data.addressConfig && this.formType !== 'single_line') {
+        const config = JSON.parse(this.data.addressConfig);
+        for (let field in config) {
+          let value = config[field]
+          if (Array.isArray(value)) {
+            data[field] = value.map(elem_id =>
+              document.getElementsByName(elem_id)[0] ? document.getElementsByName(elem_id)[0].value : ''
+            ).join(' ');
+          }
+          else{
+            data[field] = document.getElementsByName(value)[0] ? document.getElementsByName(value)[0].value : '';
+          }
         }
-      });
+      }
+      return data;
+    }
+  }
+
+  function tokenizeCreditCard(_options, params, _event, results) {
+    return new Promise(function (resolve, reject) {
+      let plugin = document.querySelector('.v-stripe_credit_card_form')
+      const targetComponent = _event.currentTarget.vComponent
+      if (plugin && plugin.vPlugin) {
+        plugin = plugin.vPlugin
+        targetComponent.disable();
+        plugin.stripe.createToken(plugin.cardNumber, plugin.stripeTokenData()).then(function (response) {
+          if (response.token) {
+            const result = {action: 'tokenize_credit_card', content: {onetime_token: response.token.id}, statusCode: 200};
+            result.content = JSON.stringify(result.content);
+            results.push(result);
+            resolve(results);
+          } else {
+            const message = response.error.message;
+            const bad_result = {
+              action: 'tokenize_credit_card',
+              contentType: 'application/json',
+              content: {errors: message},
+              statusCode: 400
+            };
+            bad_result.content = JSON.stringify(bad_result.content);
+            results.push(bad_result);
+            targetComponent.enable();
+            reject(results);
+          }
+        });
+      } else {
+        results.push({action: 'tokenize_credit_card', content: JSON.stringify({onetime_token: ''}), statusCode: 200})
+        resolve(results);
+      }
+    });
+  }
+
+  function handleElementChange(event, element) {
+    const mdcTextField = element.closest('.mdc-text-field');
+    const inputHintElement = element.closest('.v-column').querySelector('.mdc-text-field-helper-text');
+    const error = event.error;
+
+    // Stripe's JS will dispatch the `change` event *before* it updates state classes.
+    // Update element dataset state manually so listeners of the `stripeElementChange` (dispatched
+    // below) have the actual current state of the element.
+    if (event.complete) {
+      element.setAttribute('data-complete', '');
     }
     else {
-      this.cardNumber = elements.create('cardNumber', {style: style, showIcon: true});
-      this.cardNumber.mount('#card-number');
-
-      this.cardExpiry = elements.create('cardExpiry', {style: style});
-      this.cardExpiry.mount('#card-expiry');
-
-      this.cardCvc = elements.create('cardCvc', {style: style});
-      this.cardCvc.mount('#card-cvc');
+      element.removeAttribute('data-complete');
     }
+
+    if (event.empty) {
+      element.setAttribute('data-empty', '');
+    }
+    else {
+      element.removeAttribute('data-empty');
+    }
+
+    if (event.invalid) {
+      element.setAttribute('data-invalid', '');
+    }
+    else {
+      element.removeAttribute('data-invalid');
+    }
+
+    if (error && error.message) {
+      inputHintElement.textContent = error.message;
+      inputHintElement.classList.remove('v-hidden');
+      mdcTextField.classList.add('mdc-text-field--invalid');
+    }
+    else {
+      inputHintElement.classList.add('v-hidden');
+      inputHintElement.textContent = '';
+      mdcTextField.classList.remove('mdc-text-field--invalid');
+    }
+
+    element.dispatchEvent(new CustomEvent('stripeElementChange', {
+      detail: {stripeEvent: event},
+      bubbles: true
+    }));
   }
 
-  stripeTokenData() {
-    let data = {currency: this.data.currency}
-    if (this.data.addressConfig && this.formType !== 'single_line') {
-      const config = JSON.parse(this.data.addressConfig);
-      for (let field in config) {
-        let value = config[field]
-        if (Array.isArray(value)) {
-          data[field] = value.map(elem_id =>
-            document.getElementsByName(elem_id)[0] ? document.getElementsByName(elem_id)[0].value : ''
-          ).join(' ');
-        }
-        else{
-          data[field] = document.getElementsByName(value)[0] ? document.getElementsByName(value)[0].value : '';
-        }
-      }
-    }
-    return data;
-  }
-
-}
-
-function tokenizeCreditCard(_options, params, _event, results) {
-  return new Promise(function (resolve, reject) {
-    let plugin = document.querySelector('.v-stripe_credit_card_form')
-    const targetComponent = _event.currentTarget.vComponent
-    if (plugin && plugin.vPlugin) {
-      plugin = plugin.vPlugin
-      targetComponent.disable();
-      plugin.stripe.createToken(plugin.cardNumber, plugin.stripeTokenData()).then(function (response) {
-        if (response.token) {
-          const result = {action: 'tokenize_credit_card', content: {onetime_token: response.token.id}, statusCode: 200};
-          result.content = JSON.stringify(result.content);
-          results.push(result);
-          resolve(results);
-        } else {
-          const message = response.error.message;
-          const bad_result = {
-            action: 'tokenize_credit_card',
-            contentType: 'application/json',
-            content: {errors: message},
-            statusCode: 400
-          };
-          bad_result.content = JSON.stringify(bad_result.content);
-          results.push(bad_result);
-          targetComponent.enable();
-          reject(results);
-        }
-      });
-    } else {
-      results.push({action: 'tokenize_credit_card', content: JSON.stringify({onetime_token: ''}), statusCode: 200})
-      resolve(results);
-    }
-  });
-}
-
+  window.StripeCreditCardForm = StripeCreditCardForm;
+  window.tokenizeCreditCard = tokenizeCreditCard;
+})();

--- a/views/assets/js/payment_request_form.js
+++ b/views/assets/js/payment_request_form.js
@@ -1,0 +1,122 @@
+class PaymentRequestForm {
+  constructor(element) {
+    console.debug('\tPaymentRequestForm');
+    this.element = element;
+    this.data = this.element.dataset;
+    this.stripe = Stripe(this.data.stripePublishableKey);
+    this.paymentIntentPath = this.data.paymentIntentPath;
+    this.params = {};
+
+    const amount = parseInt(this.data.itemTotal, 10); // currency subunit (e.g. cents)
+    const paymentRequest = this.createPaymentRequest({
+      country: this.data.country,
+      currency: this.data.currency,
+      requestPayerName: this.data.requestName == 'true',
+      requestPayerEmail: this.data.requestEmail == 'true',
+      requestShipping: this.data.requestShipping == 'true',
+      shippingOptions: JSON.parse(this.data.shippingOptions),
+      total: {label: this.data.itemLabel, amount: amount}
+    });
+
+    paymentRequest.canMakePayment().then(result => {
+      if (result) {
+        this.stripe.elements()
+          .create('paymentRequestButton', {paymentRequest: paymentRequest})
+          .mount(this.element);
+        this.element.dispatchEvent(new Event('init_succeeded', {bubbles: true}));
+      } else {
+        console.warn('PaymentRequestForm: not allowed to make payment')
+        this.element.dispatchEvent(new Event('init_failed', {bubbles: true}));
+      }
+    });
+
+    paymentRequest.on('paymentmethod', e => {
+        fetch(this.paymentIntentPath, {method: 'POST'})
+          .then(r => r.json())
+          .then(r => {
+            const paymentIntent = r.data;
+
+            if (!(paymentIntent && paymentIntent.client_secret)) {
+              e.complete('fail');
+              throw new Error('missing payment intent');
+            }
+
+            const secret = paymentIntent.client_secret;
+
+            // Confirm the PaymentIntent without handling potential next actions
+            // (yet).
+            this.stripe.confirmCardPayment(secret,
+              {payment_method: e.paymentMethod.id},
+              {handleActions: false}
+            ).then(confirmResult => {
+              if (confirmResult.error) {
+                // Report to the browser that the payment failed, prompting it to
+                // re-show the payment interface, or show an error message and close
+                // the payment interface.
+                console.error('payment failed: ', e, confirmResult);
+                this.element.dispatchEvent(new Event('payment_failed'));
+                e.complete('fail');
+              } else {
+                // Report to the browser that the confirmation was successful,
+                // prompting it to close the browser payment method collection
+                // interface.
+                console.log('payment succeeded: ', e);
+
+                // this plugin's parameters will be sent up in the request body
+                // as a multipart form payload (notably, nested values are not
+                // supported) instead of JSON. So, send up a JSON string that
+                // can be parsed on the server. Not great, but it works for now.
+                this.params['stripe_payment_data'] = JSON.stringify(e);
+
+                e.complete('success');
+
+                // Check if the PaymentIntent requires any actions and if so let
+                // Stripe.js handle the flow.
+                if (confirmResult.paymentIntent.status === 'requires_action') {
+                  // Let Stripe.js handle the rest of the payment flow.
+                  this.stripe.confirmCardPayment(secret).then(result => {
+                    if (result.error) {
+                      // The payment failed -- ask your customer for a new payment
+                      // method.
+                      console.log('payment failed: ', e);
+                      this.element.dispatchEvent(new Event('payment_failed'));
+                    } else {
+                      // The payment has succeeded.
+                      this.element.dispatchEvent(new Event('payment_succeeded'));
+                    }
+                  });
+                } else {
+                  // The payment has succeeded.
+                  this.element.dispatchEvent(new Event('payment_succeeded'));
+                }
+              }
+            }).catch(err => {
+              console.error(err);
+              e.complete('fail');
+            });
+          })
+          .catch(err => {
+            console.error(err);
+            e.complete('fail');
+          });
+    });
+
+    paymentRequest.on('cancel', e => {
+      this.element.dispatchEvent(new Event('payment_cancelled', {bubbles: true}));
+    });
+  }
+
+  createPaymentRequest(options) {
+    return this.stripe.paymentRequest(Object.assign({
+      requestPayerName: true,
+      requestPayerEmail: true,
+      requestShipping: false
+    }, options));
+  }
+
+  prepareSubmit(params) {
+    for (const pair of Object.entries(this.params)) {
+      params.push(pair);
+    }
+  }
+}

--- a/views/components/application/_credit_card_form_multi_line.html
+++ b/views/components/application/_credit_card_form_multi_line.html
@@ -1,13 +1,13 @@
-<div class="sr-payment-form v-grid mdc-layout-grid v-padding-bottom0-left0-right0-top0 v-component v-container">
+<div class="sr-payment-form v-grid mdc-layout-grid v-component v-container v-padding--top0 v-padding--right0 v-padding--bottom0 v-padding--left0">
   <div class="mdc-layout-grid__inner">
 
-    <div class="v-column mdc-layout-grid__cell mdc-layout-grid__cell--span-6 v-padding- v-column--relative v-grid-column-align-left v-component v-container">
+    <div class="v-column mdc-layout-grid__cell mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet v-column--relative v-grid-column-align-left v-component v-container">
       <div class="v-focusable mdc-text-field mdc-text-field--outlined" style="width: 100%;">
         <div id="card-number" class="input empty v-stripe-element"></div>
         <div class="mdc-notched-outline mdc-notched-outline--upgraded mdc-notched-outline--notched">
           <div class="mdc-notched-outline__leading"></div>
           <div class="mdc-notched-outline__notch">
-            <label for="card-number" class="mdc-floating-label mdc-floating-label--float-above" style="">Card Number</label>
+            <label for="card-number" class="mdc-floating-label mdc-floating-label--float-above">Card Number</label>
           </div>
           <div class="mdc-notched-outline__trailing"></div>
         </div>
@@ -15,13 +15,13 @@
       </div>
     </div>
 
-    <div class="v-column mdc-layout-grid__cell mdc-layout-grid__cell--span-3 v-padding- v-column--relative v-grid-column-align-left v-component v-container">
+    <div class="v-column mdc-layout-grid__cell mdc-layout-grid__cell--span-3 mdc-layout-grid__cell--span-4-tablet mdc-layout-grid__cell--span-4-phone v-column--relative v-grid-column-align-left v-component v-container">
       <div class="v-focusable mdc-text-field mdc-text-field--outlined" style="width: 100%;">
-        <div id="card-expiry" class="input empty  v-stripe-element"></div>
+        <div id="card-expiry" class="input empty v-stripe-element"></div>
         <div class="mdc-notched-outline mdc-notched-outline--upgraded mdc-notched-outline--notched">
           <div class="mdc-notched-outline__leading"></div>
           <div class="mdc-notched-outline__notch">
-            <label for="card-expiry" class="mdc-floating-label mdc-floating-label--float-above" style="">Expiration</label>
+            <label for="card-expiry" class="mdc-floating-label mdc-floating-label--float-above">Expiration</label>
           </div>
           <div class="mdc-notched-outline__trailing"></div>
         </div>
@@ -29,13 +29,13 @@
       </div>
     </div>
 
-    <div class="v-column mdc-layout-grid__cell mdc-layout-grid__cell--span-2 v-padding- v-column--relative v-grid-column-align-left v-component v-container">
+    <div class="v-column mdc-layout-grid__cell mdc-layout-grid__cell--span-3 mdc-layout-grid__cell--span-4-tablet mdc-layout-grid__cell--span-4-phone v-column--relative v-grid-column-align-left v-component v-container">
       <div class="v-focusable mdc-text-field mdc-text-field--outlined" style="width: 100%;">
         <div id="card-cvc" class="input empty v-stripe-element"></div>
         <div class="mdc-notched-outline mdc-notched-outline--upgraded mdc-notched-outline--notched">
           <div class="mdc-notched-outline__leading"></div>
           <div class="mdc-notched-outline__notch">
-            <label for="card-cvc" class="mdc-floating-label mdc-floating-label--float-above" style="">CVC</label>
+            <label for="card-cvc" class="mdc-floating-label mdc-floating-label--float-above">CVC</label>
           </div>
           <div class="mdc-notched-outline__trailing"></div>
         </div>

--- a/views/components/application/_credit_card_form_multi_line.html
+++ b/views/components/application/_credit_card_form_multi_line.html
@@ -1,6 +1,5 @@
 <div class="sr-payment-form v-grid mdc-layout-grid v-component v-container v-padding--top0 v-padding--right0 v-padding--bottom0 v-padding--left0">
   <div class="mdc-layout-grid__inner">
-
     <div class="v-column mdc-layout-grid__cell mdc-layout-grid__cell--span-6 mdc-layout-grid__cell--span-12-tablet v-column--relative v-grid-column-align-left v-component v-container">
       <div class="v-focusable mdc-text-field mdc-text-field--outlined" style="width: 100%;">
         <div id="card-number" class="input empty v-stripe-element"></div>
@@ -11,7 +10,12 @@
           </div>
           <div class="mdc-notched-outline__trailing"></div>
         </div>
-
+      </div>
+      <div class="mdc-text-field-helper-line">
+        <div class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent mdc-text-field-helper-text--validation-msg v-hidden"
+             role="alert"
+             aria-live="polite">
+        </div>
       </div>
     </div>
 
@@ -25,7 +29,12 @@
           </div>
           <div class="mdc-notched-outline__trailing"></div>
         </div>
-
+      </div>
+      <div class="mdc-text-field-helper-line">
+        <div class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent mdc-text-field-helper-text--validation-msg v-hidden"
+             role="alert"
+             aria-live="polite">
+        </div>
       </div>
     </div>
 
@@ -40,7 +49,12 @@
           <div class="mdc-notched-outline__trailing"></div>
         </div>
       </div>
+      <div class="mdc-text-field-helper-line">
+        <div class="mdc-text-field-helper-text mdc-text-field-helper-text--persistent mdc-text-field-helper-text--validation-msg v-hidden"
+             role="alert"
+             aria-live="polite">
+        </div>
+      </div>
     </div>
-
   </div>
 </div>

--- a/views/components/application/_payment_request_form.erb
+++ b/views/components/application/_payment_request_form.erb
@@ -1,0 +1,23 @@
+<%
+  # TODO: fix; this is gross. for some reason if a method is defined in a POM
+  # calling a plugin with the same method defined (here,
+  # `attr_accessor :shipping_options`), the POM method is called instead of the
+  # plugin's method.
+  shipping_options = comp.__getobj__.instance_variable_get('@shipping_options')
+%>
+<div id="<%= comp.id %>"
+     class="v-plugin"
+     data-stripe-publishable-key="<%= comp.stripe_publishable_key %>"
+     data-plugin-callback="PaymentRequestForm"
+     data-item-label="<%= comp.description %>"
+     data-item-total="<%= comp.total %>"
+     data-payment-intent-path="<%= comp.payment_intent_path %>"
+     data-country="<%= comp.options[:country] %>"
+     data-currency="<%= comp.options[:currency] %>"
+     data-request-name="<%= comp.options[:request_name] %>"
+     data-request-email="<%= comp.options[:request_email] %>"
+     data-request-shipping="<%= comp.options[:request_shipping] %>"
+     data-shipping-options="<%= h JSON.dump(shipping_options) %>"
+     <%= partial "components/event", locals: {comp: comp, events: comp.events, parent_id: comp.id} %>>
+  <!-- A Stripe Element will replace all inner content. -->
+</div>

--- a/views/components/application/_stripe_header.erb
+++ b/views/components/application/_stripe_header.erb
@@ -3,6 +3,9 @@
 <script>
   <%= raw File.read(File.expand_path('../../assets/js/credit_card_form.js', __dir__)  ) %>
 </script>
+<script>
+  <%= raw File.read(File.expand_path('../../assets/js/payment_request_form.js', __dir__)  ) %>
+</script>
 <style>
   <%= raw File.read(File.expand_path('../../assets/css/credit_card_form.css', __dir__)  ) %>
 </style>

--- a/views/components/application/_stripe_js.erb
+++ b/views/components/application/_stripe_js.erb
@@ -30,5 +30,3 @@ function createStripeBankAccountToken(_options, params, _event, results) {
     return promise;
 }
 </script>
-
-


### PR DESCRIPTION
# Wallet payments
Add `stripe_payment_request_form`, which renders a browser-appropriate digital wallet payment button (when supported and available):

* Safari: Apple Pay
* Android, Chrome: Google Pay
* Others: "basic card"

## Example

```ruby
stripe_payment_request_form stripe_publishable_key: 'pk_foo12345',
                            payment_intent_path: 'some/where/payment-intents',
                            description: 'cool sweater',
                            total: 29_99 do
  event :init_succeeded do
    # client is able to make wallet payments.
  end

  event :init_failed do
    # client cannot make wallet payments.
  end

  event :payment_cancelled do
    # the user closed the browser's payment prompt dialog.
  end

  event :payment_succeeded do
    # wallet payment was successfully authorized.
  end

  event :payment_failed do
    # wallet payment did not succeed.
  end
end
```

# Credit card form

* Each field now emits a `stripeElementChange` event when its contents change.
* Each field is now decorated with one of the following state attributes when its contents change: `data-invalid`, `data-complete`, `data-empty`
* Validation errors are now rendered in the MDC text field's help/hint text area, consistent with other MDC input fields.