### PR TITLE
fix: omit shipping options when not required

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    stripe_presenter_plugin (1.3.0)
+    stripe_presenter_plugin (1.3.1)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/coprl/presenters/plugins/stripe/components/payment_request_form.rb
+++ b/lib/coprl/presenters/plugins/stripe/components/payment_request_form.rb
@@ -25,7 +25,13 @@ module Coprl
               @total = total
               @payment_intent_path = payment_intent_path
               @options = DEFAULT_OPTIONS.merge(attributes.slice(*DEFAULT_OPTIONS.keys))
-              @shipping_options = validate_shipping_options(shipping_options)
+              @shipping_options =
+                if @options[:request_shipping]
+                  validate_shipping_options(shipping_options)
+                else
+                  # Google Pay raises a JS error if shipping options are provided but not required.
+                  []
+                end
 
               super(type: :stripe_payment_request_form, **attributes, &block)
 

--- a/lib/stripe_presenter_plugin/version.rb
+++ b/lib/stripe_presenter_plugin/version.rb
@@ -1,3 +1,3 @@
 module StripePresenterPlugin
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end

--- a/views/assets/js/payment_request_form.js
+++ b/views/assets/js/payment_request_form.js
@@ -8,15 +8,21 @@ class PaymentRequestForm {
     this.params = {};
 
     const amount = parseInt(this.data.itemTotal, 10); // currency subunit (e.g. cents)
-    const paymentRequest = this.createPaymentRequest({
+    const paymentRequestData = {
       country: this.data.country,
       currency: this.data.currency,
       requestPayerName: this.data.requestName == 'true',
       requestPayerEmail: this.data.requestEmail == 'true',
       requestShipping: this.data.requestShipping == 'true',
-      shippingOptions: JSON.parse(this.data.shippingOptions),
       total: {label: this.data.itemLabel, amount: amount}
-    });
+    };
+
+    // Exclude shipping options when not needed:
+    if (paymentRequestData.requestShipping && this.data.shippingOptions) {
+      paymentRequestData.shippingOptions = JSON.parse(this.data.shippingOptions)
+    }
+
+    const paymentRequest = this.createPaymentRequest(paymentRequestData);
 
     paymentRequest.canMakePayment().then(result => {
       if (result) {

--- a/views/components/application/_payment_request_form.erb
+++ b/views/components/application/_payment_request_form.erb
@@ -4,6 +4,7 @@
   # `attr_accessor :shipping_options`), the POM method is called instead of the
   # plugin's method.
   shipping_options = comp.__getobj__.instance_variable_get('@shipping_options')
+  have_shipping_options = shipping_options&.any?
 %>
 <div id="<%= comp.id %>"
      class="v-plugin"
@@ -17,7 +18,7 @@
      data-request-name="<%= comp.options[:request_name] %>"
      data-request-email="<%= comp.options[:request_email] %>"
      data-request-shipping="<%= comp.options[:request_shipping] %>"
-     data-shipping-options="<%= h JSON.dump(shipping_options) %>"
+     <% if have_shipping_options %>data-shipping-options="<%= h JSON.dump(shipping_options) %>"<% end %>
      <%= partial "components/event", locals: {comp: comp, events: comp.events, parent_id: comp.id} %>>
   <!-- A Stripe Element will replace all inner content. -->
 </div>


### PR DESCRIPTION
Google Pay's JS raises an error if shipping options are provided but
shipping info has not been requested (via the `request_shipping`
option).

This change excludes shipping options from the data passed to the Stripe
`PaymentRequest` unless 1) the `request_shipping` option has been
specified and 2) at least one shipping option is provided.